### PR TITLE
Ignore files with names starting with '.'

### DIFF
--- a/intropyproject-classify-pet-images/get_pet_labels.py
+++ b/intropyproject-classify-pet-images/get_pet_labels.py
@@ -48,6 +48,8 @@ def get_pet_labels(image_dir):
 
     results_dic = {}
     for item in onlyfiles:
+        if item.startswith('.'):
+            continue
         label = item.split('_')
         label.pop()
         results_dic[item] = [' '.join(label).lower(), ]


### PR DESCRIPTION
During processing of files for results, ignore files with names starting with '.'